### PR TITLE
Ajout choix protocole de paiement pour les 3xcb, 4xcb

### DIFF
--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -7,8 +7,6 @@ namespace FluxSE\SyliusPayumMoneticoPlugin\Action;
 use App\Entity\Payment\GatewayConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use FluxSE\SyliusPayumMoneticoPlugin\Form\Type\MoneticoGatewayConfigurationType;
-use FluxSE\SyliusPayumMoneticoPlugin\Provider\PaymentMethodProvider;
-use FluxSE\SyliusPayumMoneticoPlugin\Provider\PaymentMethodProviderInterface;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\LogicException;
@@ -20,13 +18,6 @@ use Payum\Core\Request\GetCurrency;
 use FluxSE\SyliusPayumMoneticoPlugin\Provider\CommentProviderInterface;
 use FluxSE\SyliusPayumMoneticoPlugin\Provider\ContextProviderInterface;
 use FluxSE\SyliusPayumMoneticoPlugin\Provider\ReferenceProviderInterface;
-use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
-use Sylius\Component\Core\Factory\PaymentMethodFactoryInterface;
-use Sylius\Component\Core\Model\PaymentInterface;
-use Sylius\Component\Core\Model\PaymentMethod;
-use Sylius\Component\Core\Model\PaymentMethodInterface;
-use Sylius\Component\Core\Resolver\DefaultPaymentMethodResolver;
-use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
 use Webmozart\Assert\Assert;
 
 final class ConvertPaymentAction implements ActionInterface, GatewayAwareInterface

--- a/src/Controller/NotifyController.php
+++ b/src/Controller/NotifyController.php
@@ -27,9 +27,8 @@ final class NotifyController
 
     public function __construct(
         EntityRepository $paymentRepository,
-        Payum            $payum
-    )
-    {
+        Payum $payum
+    ) {
         $this->paymentRepository = $paymentRepository;
         $this->payum = $payum;
     }
@@ -87,7 +86,6 @@ final class NotifyController
 
         // Execute notify & status actions.
         $gateway = $this->payum->getGateway($gateway_name);
-
         $gateway->execute(new Notify($payment));
 
         // We don't invalidate payment tokens because if the customer click on go back to the store

--- a/src/Controller/NotifyController.php
+++ b/src/Controller/NotifyController.php
@@ -27,8 +27,9 @@ final class NotifyController
 
     public function __construct(
         EntityRepository $paymentRepository,
-        Payum $payum
-    ) {
+        Payum            $payum
+    )
+    {
         $this->paymentRepository = $paymentRepository;
         $this->payum = $payum;
     }
@@ -86,6 +87,7 @@ final class NotifyController
 
         // Execute notify & status actions.
         $gateway = $this->payum->getGateway($gateway_name);
+
         $gateway->execute(new Notify($payment));
 
         // We don't invalidate payment tokens because if the customer click on go back to the store

--- a/src/Form/Type/MoneticoGatewayConfigurationType.php
+++ b/src/Form/Type/MoneticoGatewayConfigurationType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 final class MoneticoGatewayConfigurationType extends AbstractType
 {
+    static $protocoles = [null => 'Classique', '1euro' => '1euro', '3xcb' => '3xcb', '4xcb' => '4xcb', 'paypal' => 'paypal', 'lyfpay' => 'lyfpay'];
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -67,6 +68,11 @@ final class MoneticoGatewayConfigurationType extends AbstractType
                     ]),
                 ],
             ])
-        ;
+            ->add('protocol', ChoiceType::class, [
+                'label' => 'flux_se.sylius_payum_monetico.fields.payment_protocol.label',
+                'expanded' => true,
+                'multiple' => false,
+                'choices' => array_flip(self::$protocoles),
+            ]);
     }
 }

--- a/src/Form/Type/MoneticoGatewayConfigurationType.php
+++ b/src/Form/Type/MoneticoGatewayConfigurationType.php
@@ -14,7 +14,15 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 final class MoneticoGatewayConfigurationType extends AbstractType
 {
-    static $protocoles = [null => 'Classique', '1euro' => '1euro', '3xcb' => '3xcb', '4xcb' => '4xcb', 'paypal' => 'paypal', 'lyfpay' => 'lyfpay'];
+    static $protocoles = [
+        null => 'flux_se.sylius_payum_monetico.protocole_type.classic',
+        '1euro' => 'flux_se.sylius_payum_monetico.protocole_type.1euro',
+        '3xcb' => 'flux_se.sylius_payum_monetico.protocole_type.3xcb',
+        '4xcb' => 'flux_se.sylius_payum_monetico.protocole_type.4xcb',
+        'paypal' => 'flux_se.sylius_payum_monetico.protocole_type.paypal',
+        'lyfpay' => 'flux_se.sylius_payum_monetico.protocole_type.lyfpay'
+    ];
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder

--- a/src/Provider/ProtocolProvider.php
+++ b/src/Provider/ProtocolProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumMoneticoPlugin\Provider;
+
+use FluxSE\SyliusPayumMoneticoPlugin\Form\Type\MoneticoGatewayConfigurationType;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+class ProtocolProvider implements ProtocolProviderInterface
+{
+
+    public function getProtocol(PaymentInterface $payment): ?string
+    {
+        $gatewayConfig = $payment->getMethod()->getGatewayConfig()->getConfig();
+        if ($gatewayConfig && array_key_exists('protocol',$gatewayConfig) && $gatewayConfig['protocol']) {
+            return $gatewayConfig['protocol'];
+        }
+        return null;
+
+    }
+    public function getDesactiveMoyenPaiement(PaymentInterface $payment): string
+    {
+        $protocoles = MoneticoGatewayConfigurationType::$protocoles;
+        array_shift($protocoles);
+        $protocoles = implode(',', array_flip($protocoles));
+        return  $protocoles;
+
+    }
+}

--- a/src/Provider/ProtocolProviderInterface.php
+++ b/src/Provider/ProtocolProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\SyliusPayumMoneticoPlugin\Provider;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+interface ProtocolProviderInterface
+{
+    public function getProtocol(PaymentInterface $payment): ?string;
+    
+    public function getDesactiveMoyenPaiement(PaymentInterface $payment): string;
+}

--- a/src/Resources/config/services/actions.yaml
+++ b/src/Resources/config/services/actions.yaml
@@ -19,6 +19,6 @@ services:
       $contextProvider: '@flux_se.sylius_payum_monetico.provider.context'
       $referenceProvider: '@flux_se.sylius_payum_monetico.provider.reference'
       $commentProvider: '@flux_se.sylius_payum_monetico.provider.comment'
-      $entityManager: '@doctrine.orm.entity_manager'
+      $protocolProvider: '@flux_se.sylius_payum_monetico.provider.protocol'
     tags:
       - { name: payum.action, factory: monetico, prepend: true }

--- a/src/Resources/config/services/actions.yaml
+++ b/src/Resources/config/services/actions.yaml
@@ -19,5 +19,6 @@ services:
       $contextProvider: '@flux_se.sylius_payum_monetico.provider.context'
       $referenceProvider: '@flux_se.sylius_payum_monetico.provider.reference'
       $commentProvider: '@flux_se.sylius_payum_monetico.provider.comment'
+      $entityManager: '@doctrine.orm.entity_manager'
     tags:
       - { name: payum.action, factory: monetico, prepend: true }

--- a/src/Resources/config/services/providers.yaml
+++ b/src/Resources/config/services/providers.yaml
@@ -12,5 +12,6 @@ services:
         class: FluxSE\SyliusPayumMoneticoPlugin\Provider\ContextProvider
         arguments:
             - "@flux_se.sylius_payum_monetico.provider.address"
-    flux_se.sylius_payum_monetico.provider.payment_method_provider:
-        class: FluxSE\SyliusPayumMoneticoPlugin\Provider\PaymentMethodProvider
+
+    flux_se.sylius_payum_monetico.provider.protocol:
+        class: FluxSE\SyliusPayumMoneticoPlugin\Provider\ProtocolProvider

--- a/src/Resources/config/services/providers.yaml
+++ b/src/Resources/config/services/providers.yaml
@@ -12,3 +12,5 @@ services:
         class: FluxSE\SyliusPayumMoneticoPlugin\Provider\ContextProvider
         arguments:
             - "@flux_se.sylius_payum_monetico.provider.address"
+    flux_se.sylius_payum_monetico.provider.payment_method_provider:
+        class: FluxSE\SyliusPayumMoneticoPlugin\Provider\PaymentMethodProvider

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -19,5 +19,8 @@ flux_se:
       test: Test
     protocole_type:
       classic: Classic
+      1euro: 1euro
       3xcb: 3X CB
       4xcb: 4x CB
+      paypal: Paypal
+      lyfpay: Lyfpay

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -18,6 +18,6 @@ flux_se:
       production: Production
       test: Test
     protocole_type:
-      classic: Classique
+      classic: Classic
       3xcb: 3X CB
       4xcb: 4x CB

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -12,6 +12,12 @@ flux_se:
       company:
         label: COMPANY
         help: max 20 characters
+      payment_protocol:
+        label: Payment protocol
     mode:
       production: Production
       test: Test
+    protocole_type:
+      classic: Classique
+      3xcb: 3X CB
+      4xcb: 4x CB

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -12,6 +12,12 @@ flux_se:
       company:
         label: Société
         help: max 20 charactères
+      payment_protocol:
+        label: Protocole de paiement
     mode:
       production: Production
       test: Test
+    protocole_type:
+      classic: Classique
+      3xcb: 3X CB
+      4xcb: 4x CB

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -19,5 +19,8 @@ flux_se:
       test: Test
     protocole_type:
       classic: Classique
+      1euro: 1euro
       3xcb: 3X CB
       4xcb: 4x CB
+      paypal: Paypal
+      lyfpay: Lyfpay


### PR DESCRIPTION
On peut maintenant choisir si il s'agit d'un paiement Classique CB ou être redirigé vers le 3x CB ou 4x CB ... en créant différentes méthodes de paiement
<img width="200" alt="image" src="https://user-images.githubusercontent.com/13310096/130855708-0ae48480-dad3-41b7-a783-240165a5e7ef.png">

<img width="865" alt="image" src="https://user-images.githubusercontent.com/13310096/130855951-e70d016f-7a17-4015-92c2-7fd7e9a9c30c.png">

