### PR TITLE
Payment attempt inside Monetico portal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,8 @@ jobs:
             matrix:
                 php: [7.3, 7.4, 8.0]
                 symfony: [^4.4, ^5.4]
-                sylius: [~1.8.0, ~1.9.0, ~1.10.0]
-                node: [10.x]
+                sylius: [~1.8.0, ~1.9.0, ~1.10.0, ~1.11.0]
+                node: [12.x]
                 mysql: [5.7]
 
                 exclude:
@@ -126,6 +126,15 @@ jobs:
                     -
                         sylius: ~1.10.0
                         php: 7.3
+                    -
+                        sylius: ~1.11.0
+                        php: 7.3
+                    -
+                        sylius: ~1.11.0
+                        php: 7.4
+                    -
+                        sylius: ~1.11.0
+                        symfony: ^4.4
 
         env:
             APP_ENV: test

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
   "description": "Payum Monetico gateway plugin for Sylius",
   "license": "MIT",
   "authors": [
-      {
-          "name": "Francis HILAIRE",
-          "email": "Prometee@users.noreply.github.com"
-      }
+    {
+      "name": "Francis HILAIRE",
+      "email": "Prometee@users.noreply.github.com"
+    }
   ],
   "require": {
-    "sylius/sylius": "^1.5",
-    "ekyna/payum-monetico": "^1.5"
+    "ekyna/payum-monetico": "^1.5",
+    "sylius/sylius": "~1.11.0"
   },
   "require-dev": {
     "ext-json": "*",
@@ -33,6 +33,7 @@
     "phpstan/phpstan-strict-rules": "^0.12.0",
     "phpstan/phpstan-webmozart-assert": "0.12.12",
     "phpunit/phpunit": "^9.5",
+    "polishsymfonycommunity/symfony-mocker-container": "^1.0",
     "sylius-labs/coding-standard": "^4.0",
     "symfony/browser-kit": "^4.4 || ^5.4",
     "symfony/debug-bundle": "^4.4 || ^5.4",
@@ -66,11 +67,11 @@
       "@php vendor/bin/psalm"
     ],
     "analyse-with-ecs": [
-        "@php vendor/bin/ecs check src",
-        "@analyse"
+      "@php vendor/bin/ecs check src",
+      "@analyse"
     ],
     "fix": [
-        "@php vendor/bin/ecs check src --fix"
+      "@php vendor/bin/ecs check src --fix"
     ],
     "post-install-cmd": [
       "@php bin/create_node_symlink.php"

--- a/features/shop/paying_with_monetico_during_checkout.feature
+++ b/features/shop/paying_with_monetico_during_checkout.feature
@@ -50,3 +50,14 @@ Feature: Paying with Monetico during checkout
     And I click on "go back" during my Monetico payment
     Then I should be notified that my payment has been cancelled
     And I should be able to pay again
+
+  @ui
+  Scenario: Retrying the payment with success inside Monetico portal
+    Given I added product "PHP T-Shirt" to the cart
+    And I have proceeded selecting "Monetico" payment method
+    And I have confirmed my order with Monetico payment
+    And I get redirected to Monetico and fail my attempt
+    And I retry my payment attempt and succeed
+    When I get back from the Monetico portal
+    Then I should be notified that my payment has been completed
+    And I should see the thank you page

--- a/src/Extension/PaymentResponseExtension.php
+++ b/src/Extension/PaymentResponseExtension.php
@@ -16,16 +16,18 @@ class PaymentResponseExtension implements ExtensionInterface
 {
     public function onPreExecute(Context $context): void
     {
-        return;
     }
 
     public function onExecute(Context $context): void
     {
-        return;
     }
 
     public function onPostExecute(Context $context): void
     {
+        if (null !== $context->getException()) {
+            return;
+        }
+
         $request = $context->getRequest();
         if (false === $request instanceof PaymentResponse) {
             return;

--- a/tests/Application/.env
+++ b/tests/Application/.env
@@ -27,3 +27,10 @@ JWT_PASSPHRASE=acme_plugin_development
 # Delivery is disabled by default via "null://localhost"
 MAILER_URL=smtp://localhost
 ###< symfony/swiftmailer-bundle ###
+
+###> symfony/messenger ###
+# Choose one of the transports below
+# MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
+MESSENGER_TRANSPORT_DSN=doctrine://default
+# MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
+###< symfony/messenger ###

--- a/tests/Application/config/sylius/1.11/bundles.php
+++ b/tests/Application/config/sylius/1.11/bundles.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    BabDev\PagerfantaBundle\BabDevPagerfantaBundle::class => ['all' => true],
+    SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
+    Sylius\Calendar\SyliusCalendarBundle::class => ['all' => true],
+];

--- a/tests/Application/config/sylius/1.11/packages/dev/jms_serializer.yaml
+++ b/tests/Application/config/sylius/1.11/packages/dev/jms_serializer.yaml
@@ -1,0 +1,12 @@
+jms_serializer:
+    visitors:
+        json_serialization:
+            options:
+                - JSON_PRETTY_PRINT
+                - JSON_UNESCAPED_SLASHES
+                - JSON_PRESERVE_ZERO_FRACTION
+        json_deserialization:
+            options:
+                - JSON_PRETTY_PRINT
+                - JSON_UNESCAPED_SLASHES
+                - JSON_PRESERVE_ZERO_FRACTION

--- a/tests/Application/config/sylius/1.11/packages/jms_serializer.yaml
+++ b/tests/Application/config/sylius/1.11/packages/jms_serializer.yaml
@@ -1,0 +1,4 @@
+jms_serializer:
+    visitors:
+        xml_serialization:
+            format_output: '%kernel.debug%'

--- a/tests/Application/config/sylius/1.11/packages/prod/jms_serializer.yaml
+++ b/tests/Application/config/sylius/1.11/packages/prod/jms_serializer.yaml
@@ -1,0 +1,10 @@
+jms_serializer:
+    visitors:
+        json_serialization:
+            options:
+                - JSON_UNESCAPED_SLASHES
+                - JSON_PRESERVE_ZERO_FRACTION
+        json_deserialization:
+            options:
+                - JSON_UNESCAPED_SLASHES
+                - JSON_PRESERVE_ZERO_FRACTION

--- a/tests/Application/config/sylius/1.11/packages/security.yaml
+++ b/tests/Application/config/sylius/1.11/packages/security.yaml
@@ -1,0 +1,148 @@
+parameters:
+    sylius.security.admin_regex: "^/%sylius_admin.path_name%"
+    sylius.security.api_regex: "^/api"
+    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|new-api|api/.*|api$|media/.*)[^/]++"
+    sylius.security.new_api_route: "/new-api"
+    sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
+    sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"
+    sylius.security.new_api_admin_regex: "^%sylius.security.new_api_admin_route%"
+    sylius.security.new_api_shop_route: "%sylius.security.new_api_route%/shop"
+    sylius.security.new_api_shop_regex: "^%sylius.security.new_api_shop_route%"
+
+security:
+    always_authenticate_before_granting: true
+    providers:
+        sylius_admin_user_provider:
+            id: sylius.admin_user_provider.email_or_name_based
+        sylius_api_admin_user_provider:
+            id: sylius.admin_user_provider.email_or_name_based
+        sylius_shop_user_provider:
+            id: sylius.shop_user_provider.email_or_name_based
+        sylius_api_shop_user_provider:
+            id: sylius.shop_user_provider.email_or_name_based
+        sylius_api_chain_provider:
+            chain:
+                providers: [sylius_api_shop_user_provider, sylius_api_admin_user_provider]
+
+    encoders:
+        Sylius\Component\User\Model\UserInterface: argon2i
+    firewalls:
+        admin:
+            switch_user: true
+            context: admin
+            pattern: "%sylius.security.admin_regex%"
+            provider: sylius_admin_user_provider
+            form_login:
+                provider: sylius_admin_user_provider
+                login_path: sylius_admin_login
+                check_path: sylius_admin_login_check
+                failure_path: sylius_admin_login
+                default_target_path: sylius_admin_dashboard
+                use_forward: false
+                use_referer: true
+                csrf_token_generator: security.csrf.token_manager
+                csrf_parameter: _csrf_admin_security_token
+                csrf_token_id: admin_authenticate
+            remember_me:
+                secret: "%env(APP_SECRET)%"
+                path: "/%sylius_admin.path_name%"
+                name: APP_ADMIN_REMEMBER_ME
+                lifetime: 31536000
+                remember_me_parameter: _remember_me
+            logout:
+                path: sylius_admin_logout
+                target: sylius_admin_login
+            anonymous: true
+
+        new_api_admin_user:
+            pattern: "%sylius.security.new_api_route%/admin-user-authentication-token"
+            provider: sylius_admin_user_provider
+            stateless: true
+            anonymous: true
+            json_login:
+                check_path: "%sylius.security.new_api_route%/admin-user-authentication-token"
+                username_path: email
+                password_path: password
+                success_handler: lexik_jwt_authentication.handler.authentication_success
+                failure_handler: lexik_jwt_authentication.handler.authentication_failure
+            guard:
+                authenticators:
+                    - lexik_jwt_authentication.jwt_token_authenticator
+
+        new_api_shop_user:
+            pattern: "%sylius.security.new_api_route%/shop-user-authentication-token"
+            provider: sylius_shop_user_provider
+            stateless: true
+            anonymous: true
+            json_login:
+                check_path: "%sylius.security.new_api_route%/shop-user-authentication-token"
+                username_path: email
+                password_path: password
+                success_handler: lexik_jwt_authentication.handler.authentication_success
+                failure_handler: lexik_jwt_authentication.handler.authentication_failure
+            guard:
+                authenticators:
+                    - lexik_jwt_authentication.jwt_token_authenticator
+
+        new_api:
+            pattern: "%sylius.security.new_api_regex%/*"
+            provider: sylius_api_chain_provider
+            stateless: true
+            anonymous: lazy
+            guard:
+                authenticators:
+                    - lexik_jwt_authentication.jwt_token_authenticator
+
+        shop:
+            switch_user: { role: ROLE_ALLOWED_TO_SWITCH }
+            context: shop
+            pattern: "%sylius.security.shop_regex%"
+            provider: sylius_shop_user_provider
+            form_login:
+                success_handler: sylius.authentication.success_handler
+                failure_handler: sylius.authentication.failure_handler
+                provider: sylius_shop_user_provider
+                login_path: sylius_shop_login
+                check_path: sylius_shop_login_check
+                failure_path: sylius_shop_login
+                default_target_path: sylius_shop_homepage
+                use_forward: false
+                use_referer: true
+                csrf_token_generator: security.csrf.token_manager
+                csrf_parameter: _csrf_shop_security_token
+                csrf_token_id: shop_authenticate
+            remember_me:
+                secret: "%env(APP_SECRET)%"
+                name: APP_SHOP_REMEMBER_ME
+                lifetime: 31536000
+                remember_me_parameter: _remember_me
+            logout:
+                path: sylius_shop_logout
+                target: sylius_shop_login
+                invalidate_session: false
+                success_handler: sylius.handler.shop_user_logout
+            anonymous: true
+
+        dev:
+            pattern:  ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+
+    access_control:
+        - { path: "%sylius.security.admin_regex%/_partial", role: IS_AUTHENTICATED_ANONYMOUSLY, ips: [127.0.0.1, ::1] }
+        - { path: "%sylius.security.admin_regex%/_partial", role: ROLE_NO_ACCESS }
+        - { path: "%sylius.security.shop_regex%/_partial", role: IS_AUTHENTICATED_ANONYMOUSLY, ips: [127.0.0.1, ::1] }
+        - { path: "%sylius.security.shop_regex%/_partial", role: ROLE_NO_ACCESS }
+
+        - { path: "%sylius.security.admin_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.api_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.shop_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
+
+        - { path: "%sylius.security.shop_regex%/register", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.shop_regex%/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
+
+        - { path: "%sylius.security.admin_regex%", role: ROLE_ADMINISTRATION_ACCESS }
+        - { path: "%sylius.security.api_regex%/.*", role: ROLE_API_ACCESS }
+        - { path: "%sylius.security.shop_regex%/account", role: ROLE_USER }
+
+        - { path: "%sylius.security.new_api_admin_regex%/.*", role: ROLE_API_ACCESS }
+        - { path: "%sylius.security.new_api_shop_regex%/.*", role: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/tests/Behat/Context/Ui/Shop/MoneticoShopContext.php
+++ b/tests/Behat/Context/Ui/Shop/MoneticoShopContext.php
@@ -46,12 +46,55 @@ class MoneticoShopContext extends MinkContext implements Context
      */
     public function iGetRedirectedToMonetico(): void
     {
-        $postData = [
+        $postData = $this->getPostDataWithCodeRetour('paiement');
+        $this->paymentPage->notify($postData);
+        $this->paymentPage->capture();
+    }
+
+    /**
+     * @Given I get redirected to Monetico and fail my attempt
+     */
+    public function IGetRedirectedToMoneticoAndFailMyAttempt(): void
+    {
+        $postData = $this->getPostDataWithCodeRetour('canceled');
+        $this->paymentPage->notify($postData);
+    }
+
+    /**
+     * @Given I retry my payment attempt and succeed
+     */
+    public function IRetryMyPaymentAttemptAndSucceed(): void
+    {
+        $postData = $this->getPostDataWithCodeRetour('paiement');
+        $this->paymentPage->notify($postData);
+    }
+
+    /**
+     * @Given I have clicked on "go back" during my Monetico payment
+     * @When I click on "go back" during my Monetico payment
+     * @When I get back from the Monetico portal
+     */
+    public function iCancelMyMoneticoPayment()
+    {
+        $this->paymentPage->capture();
+    }
+
+    /**
+     * @When I try to pay again Monetico payment
+     */
+    public function iTryToPayAgainMoneticoPayment(): void
+    {
+        $this->orderDetails->pay();
+    }
+
+    private function getPostDataWithCodeRetour(string $codeRetour): array
+    {
+        return [
             'TPE' => MoneticoContext::TPE,
             'date' => '05/12/2006_a_11:55:23',
             'montant' => '19.99USD',
             'texte-libre' => 'LeTexteLibre',
-            'code-retour' => 'paiement',
+            'code-retour' => $codeRetour,
             'cvx' => 'oui',
             'vld' => '1208',
             'brand' => 'VI',
@@ -76,27 +119,7 @@ class MoneticoShopContext extends MinkContext implements Context
                     'transactionID' => '555bd9d9-1cf1-4ba8-b37c-1a96bc8b603a',
                     'authenticationValue' => 'cmJvd0I4SHk3UTRkYkFSQ3FYY3U=',
                 ],
-            ])),
+            ], JSON_THROW_ON_ERROR)),
         ];
-
-        $this->paymentPage->notify($postData);
-        $this->paymentPage->capture();
-    }
-
-    /**
-     * @Given I have clicked on "go back" during my Monetico payment
-     * @When I click on "go back" during my Monetico payment
-     */
-    public function iCancelMyMoneticoPayment()
-    {
-        $this->paymentPage->capture();
-    }
-
-    /**
-     * @When I try to pay again Monetico payment
-     */
-    public function iTryToPayAgainMoneticoPayment(): void
-    {
-        $this->orderDetails->pay();
     }
 }

--- a/tests/Behat/Resources/suites.yaml
+++ b/tests/Behat/Resources/suites.yaml
@@ -26,7 +26,7 @@ default:
                 - sylius.behat.context.ui.shop.locale
                 - tests.flux_se.sylius_payum_monetico.behat.context.ui.admin.managing_payment_methods
             filters:
-                tags: "@managing_payment_method && @ui"
+                tags: "@managing_payment_method&&@ui"
         paying_with_monetico_session_checkout_during_checkout:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm
@@ -69,4 +69,4 @@ default:
 
                 - tests.flux_se.sylius_payum_monetico.behat.context.ui.shop_monetico
             filters:
-                tags: "@paying_with_monetico_session_checkout_during_checkout && @ui"
+                tags: "@paying_with_monetico_session_checkout_during_checkout&&@ui"


### PR DESCRIPTION
This PR is solving #24 

The notify URL is called twice but the second one fail because no `Payment` with the right reference is found.

Sylius is creating a new `Payment` when the previous one is canceled or failed.
The `NotifyController` will now get the previous canceled `Payment` get the `Order` and try to find the state `new` `Payment`, set the required `details` into it and giv it to a Payum `Notify` request.