### PR TITLE
Modification of the maximum number of characters in address field

### DIFF
--- a/src/Provider/AddressProvider.php
+++ b/src/Provider/AddressProvider.php
@@ -38,7 +38,7 @@ final class AddressProvider implements AddressProviderInterface
     }
 
     /** @return string[] */
-    private function splitWords(string $text, int $width = 50): array
+    private function splitWords(string $text, int $width = 48): array
     {
         $words = explode(' ', $text);
         $text = '';


### PR DESCRIPTION
Monetico returns an error if the number of characters in the address field is greater than 48. So modification of the number of characters before the split from 50 to 48